### PR TITLE
Integrated a scatter plot visualization of NBA team win pct vs fake STAR value

### DIFF
--- a/public/js/charts/reusable_scatter_plot.js
+++ b/public/js/charts/reusable_scatter_plot.js
@@ -93,16 +93,52 @@ d3.custom.scatterPlot = function module() {
           .style("fill", function(d) { return d.teamColor1; })
           .attr("opacity", 0.8);
 
-      svg.select(".chart-group")
+      // update dot position on data change
+      dots.transition()
+          .duration(duration)
+          .ease(ease)
+          .attr("r", 15)
+          .attr("cx", function(d) { return x(d.starVal); })
+          .attr("cy", function(d) { return y(d.winPct); })
+          .style("fill", function(d) { return d.teamColor1; });
+
+      dots.exit().transition().style({opacity: 0}).remove();
+
+      var teamLabels = svg.select(".chart-group")
         .selectAll('.team-label')
-        .data(_data)
-        .enter().append("text")
+        .data(_data);
+
+
+      teamLabels.enter().append("text")
         .classed('team-label', true)
         .attr("x", function(d) { return x(d.starVal); })
         .attr("y", function(d) { return y(d.winPct) + 3; })
         .text(function(d) { return d.abbreviation; })
         .style("fill", function(d) { return d.teamColor2; })
         .attr("text-anchor", "middle");
+
+      // update label position on data change
+      dots.transition()
+          .duration(duration)
+          .ease(ease)
+          .attr("r", 15)
+          .attr("cx", function(d) { return x(d.starVal); })
+          .attr("cy", function(d) { return y(d.winPct); })
+          .style("fill", function(d) { return d.teamColor1; });
+
+      dots.exit().transition().style({opacity: 0}).remove();
+
+      teamLabels.transition()
+        .duration(duration)
+        .ease(ease)
+        .attr("x", function(d) { return x(d.starVal); })
+        .attr("y", function(d) { return y(d.winPct) + 3; })
+        .text(function(d) { return d.abbreviation; })
+        .style("fill", function(d) { return d.teamColor2; })
+        .attr("text-anchor", "middle");
+
+      teamLabels.exit().transition().style({opacity: 0}).remove();
+
 
       // var legend = svg.selectAll(".legend")
       //     .data(color.domain())

--- a/public/js/controllers/chartCtrl.js
+++ b/public/js/controllers/chartCtrl.js
@@ -417,44 +417,48 @@ angular.module('mean.chart')
     };
 
     $scope.options = {width: 500, height: 300};
-    $scope.data = [1, 2, 3, 4];
+    // $scope.data = [1, 2, 3, 4];
     
-    $scope.hovered = function(d){
-      $scope.barValue = d;
-      $scope.$apply();
-    };
+    // $scope.hovered = function(d){
+    //   $scope.barValue = d;
+    //   $scope.$apply();
+    // };
 
-    $scope.barValue = 'None';
+    // $scope.barValue = 'None';
 
     $scope.calculateAllTeamStarVals = function (){
+      console.log("calculateAllTeamStarVals");
       $scope.teams.forEach(function (team){
-        $scope.calculateTeamStar(team);
+        // $scope.calculateTeamStar(team);
+        team.starVal += 5000000;
       });
-      console.log($scope.teams);
+      console.log($scope.data);
     };
 
     $scope.calculateTeamStar = function (team) {
+      console.log("inside calculateTeamStar");
       $http.get('http://localhost:3000/teams/'+team.abbreviation).success(function (teamData){
         var teamStarVal = 0;
         teamData.forEach(function (player) {
           teamStarVal += $scope.calculatePlayerStar(player);
         });
         team.starVal = teamStarVal;
-        console.log(team.abbreviation,team.starVal);
+        // console.log(team.abbreviation,team.starVal);
       });
     };
 
     $scope.calculatePlayerStar = function (player, weights) {
+      console.log("inside calculatePlayerStar");
       weights = weights || $scope.stats;
       var starStatistic = 0;
-      for (key in weights){
+      for (var key in weights){
         starStatistic += player[key]*parseFloat(weights[key].weight);
       }
       return player["Total_MIN"]*starStatistic;
     };
-    
-    $scope.options = {height: 500, width: 900};
+
     $scope.data = $scope.teams;
+    console.log($scope.data);
 
     $scope.hovered = function(d){
       console.log(d);

--- a/public/js/directives/scatterPlotDirective.js
+++ b/public/js/directives/scatterPlotDirective.js
@@ -6,8 +6,7 @@ angular.module('mean.chart')
     replace: true,
     template: '<div class="chart"></div>',
     scope:{
-      height: '=height',
-      width: '=width',
+      // height: '=height',
       data: '=data',
       hovered: '&hovered'
     },
@@ -18,12 +17,10 @@ angular.module('mean.chart')
       });
 
       scope.$watch('data', function (newVal, oldVal) {
-        chartEl.datum(newVal).call(chart);
-      });
-
-      // scope.$watch('x-pos', function(d, i){
-      //   chartEl.call(chart.x-(scope.height));
-      // });
+        if (newVal) {
+          chartEl.datum(newVal).call(chart);
+        }
+      }, true);
     }
   };
 });


### PR DESCRIPTION
The scatter plot is accessible at the root url '/#!'  Checkout chartCtrl.js in the controllers directory to see the format of the object used to generated the test data.  BTW, the win_pct for each team was scraped from NBA.stats, so it is accurate, however the STAR value is randomly generated.  My next plan of attack is to determine an efficient mechanism to connect the output of the slider logic to the starVal property of a selected team.  Let me know if any of you have any questions.
