### PR TITLE
2nd Attempt @ prettifying grouped sliders

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,9 +1,15 @@
 body {
   font: 14px sans-serif
   color: #ccc;
+  background-color: #fafafa;
+}
+.container {
+  width: 1170px;
 }
 .chart-container {
-  width: 938px;
+  float: left;
+  background-color: #fff;
+  width: 840px;
   height: 515px;
   border: 1px solid #ccc;
 }
@@ -35,15 +41,18 @@ body {
 
 /* Slider Styles
  * ==========================================================================*/
+.slider-container {
+  float: left;
+  margin-left: 14px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33)
+}
 .slider-shell {
-  border-right: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-  border-left: 1px solid #ccc;
+  width: 300px;
 }
 .top-slider {
   background-color: #f7f7f7;
   padding: 8px;
-  border-bottom: 1px solid #ccc;
+  border-top: 1px solid #ccc;
 }
 .nested-sliders-shell {
   background-color: #fff;
@@ -54,10 +63,10 @@ body {
   list-style:none;
 }
 .weight {
-  margin-left: 45px;
+  margin-left: 30px;
 }
 
-/* Slider Styles
+/* Power Rank Table Styles
  * ==========================================================================*/
 .team-badge {
   width: 50px;
@@ -70,7 +79,6 @@ body {
 .hidden {
   display:none;
 }
-
 
 .players {
   list-style: none;

--- a/public/js/controllers/chartCtrl.js
+++ b/public/js/controllers/chartCtrl.js
@@ -1,7 +1,7 @@
 angular.module('mean.chart')
   .controller('chartCtrl', ['$scope', '$http', 'Global', 'Stats', function ($scope, $http, Global, Stats) {
     
-    $scope.options = {width: 940, height: 500};
+    $scope.options = {width: 840, height: 500};
     $scope.teams = Stats.teams;
     $scope.calculateAllTeamStarVals = Stats.calculateAllTeamStarVals;
     $scope.changeSliders = Stats.changeSliders;

--- a/public/views/chart.html
+++ b/public/views/chart.html
@@ -2,22 +2,24 @@
   <div class="chart-container">
     <scatter-plot height="options.height" width="options.width" data="teams" hovered="hovered(args)"></scatter-plot>  
   </div>
-    <div class="slider-shell" ng-repeat="(groupName, group) in nestedSliders">
-      <div class="top-slider">
-        <label><a ng-click="isCollapsed = !isCollapsed">{{groupName}}</a></label>
-        <input type = "range" ng-change="changeSliders(nestedSliders,groupName);calculateAllTeamStarVals(teamStatsNorm,teams,stats);" min="0" max="5" step="0.5" ng-model="group.main"/>
-        <span class="weight badge">{{group.main}}</span>
-      </div>
-      <div class="nested-sliders-shell" collapse="isCollapsed">
-        <!-- <a ng-click = "group.show = !group.show">expand</a> -->
-        <ul class="nested-sliders">
-        <!-- <ul ng-show = "group.show"> -->
-          <li ng-repeat="(statName, statNum) in group" ng-show = "statNum.weight > -1">
-            <label>{{statName}}</label>
-            <input ng-model="statNum.weight" type="range" min="0" max="5" step="0.5" ng-change="calculateAllTeamStarVals(teamStatsNorm,teams,stats)"/>
-            <span class="weight badge">{{statNum.weight}}</span>
-          </li>
-        </ul>
+    <div class="slider-container">
+      <div class="slider-shell" ng-repeat="(groupName, group) in nestedSliders">
+        <div class="top-slider">
+          <label><a ng-click="isCollapsed = !isCollapsed">{{groupName}}</a></label>
+          <input type = "range" ng-change="changeSliders(nestedSliders,groupName);calculateAllTeamStarVals(teamStatsNorm,teams,stats);" min="0" max="5" step="0.5" ng-model="group.main"/>
+          <span class="weight badge">{{group.main}}</span>
+        </div>
+        <div class="nested-sliders-shell" collapse="isCollapsed">
+          <!-- <a ng-click = "group.show = !group.show">expand</a> -->
+          <ul class="nested-sliders">
+          <!-- <ul ng-show = "group.show"> -->
+            <li ng-repeat="(statName, statNum) in group" ng-show = "statNum.weight > -1">
+              <label>{{statName}}</label>
+              <input ng-model="statNum.weight" type="range" min="0" max="5" step="0.5" ng-change="calculateAllTeamStarVals(teamStatsNorm,teams,stats)"/>
+              <span class="weight badge">{{statNum.weight}}</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
 </div>


### PR DESCRIPTION
I moved the grouped sliders from the accordion component (ui-bootstrap) to the simpler collapse component.  This allowed me to specify that the sliders will expand and collapse when the group name label is clicked.  Also, I widen the layout of the app and moved the grouped sliders to the right side of the chart.  This fixes the real estate issue.  Let me know if you have any suggestions or questions.
